### PR TITLE
Add custom metrics support & default exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,47 @@ Create a compojure route so that the prometheus server can poll your application
 (GET "/metrics" [] (prometheus/dump-metrics your-prometheus-collector-registry))
 ```
 
+## Example with custom metrics
+
+```clojure
+(ns prometheus.example
+  (:require [prometheus.core :as prometheus]
+            [ring.server.standalone :refer [serve]]))
+
+(defonce store (atom nil))
+
+(defn register-metrics [store]
+  (->
+    store
+    (prometheus/register-counter "test" "some_counter" "some test" ["foo"])
+    (prometheus/register-gauge "test" "some_gauge" "some test" ["foo"])
+    (prometheus/register-histogram "test" "some_histogram" "some test" ["foo"] [0.7 0.8 0.9])))
+
+(defn init! []
+  (->> (prometheus/init-defaults)
+       (register-metrics)
+       (reset! store)))
+
+(defn handler [_]
+  (prometheus/increase-counter @store "test" "some_counter" ["bar"] 3)
+  (prometheus/set-gauge @store "test" "some_gauge" 101 ["bar"])
+  (prometheus/track-observation @store "test" "some_histogram" 0.71 ["bar"])
+  (prometheus/dump-metrics (:registry @store)))
+
+
+(defn -main [&]
+  (init!)
+  (serve
+    (prometheus/instrument-handler handler
+                                   "test_app"
+                                   (:registry @store))))
+
+```
+
+Run the example server:
+
+    lein run -m prometheus.example
+
 ## License
 
 Copyright 2014 SoundCloud, Inc.

--- a/project.clj
+++ b/project.clj
@@ -9,6 +9,7 @@
 
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [io.prometheus/simpleclient "0.0.11"]
+                 [io.prometheus/simpleclient_hotspot "0.0.11"]
                  [io.prometheus/simpleclient_common "0.0.11"]]
 
   :min-lein-version "2.4.3"

--- a/project.clj
+++ b/project.clj
@@ -17,4 +17,5 @@
 
   ;:global-vars {*warn-on-reflection* true}
 
-  :profiles {:dev {:dependencies [[ring-mock "0.1.5"]]}})
+  :profiles {:dev {:dependencies [[ring-mock "0.1.5"]
+                                  [ring-server "0.4.0"]]}})

--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,8 @@
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [io.prometheus/simpleclient "0.0.11"]
                  [io.prometheus/simpleclient_hotspot "0.0.11"]
-                 [io.prometheus/simpleclient_common "0.0.11"]]
+                 [io.prometheus/simpleclient_common "0.0.11"]
+                 [io.prometheus/simpleclient_pushgateway "0.0.11"]]
 
   :min-lein-version "2.4.3"
 

--- a/src/prometheus/core.clj
+++ b/src/prometheus/core.clj
@@ -6,6 +6,7 @@
     (java.io StringWriter)
     (io.prometheus.client.hotspot DefaultExports)
     (io.prometheus.client.exporter.common TextFormat)
+    (io.prometheus.client.exporter PushGateway)
     (io.prometheus.client Counter Histogram Counter$Child Histogram$Child CollectorRegistry Gauge Gauge$Child)))
 
 ; more useful set of buckets for microservice APIs than the defaults provided by the Histogram class
@@ -134,3 +135,8 @@
     {:status  200
      :headers {"Content-Type" TextFormat/CONTENT_TYPE_004}
      :body    (.toString writer)}))
+
+(defn push-metrics!
+  "Push metrics to the Prometheus push gateway."
+  [^CollectorRegistry registry ^String hostname ^String job-name]
+  (doto (PushGateway. hostname) (.pushAdd registry job-name)))

--- a/src/prometheus/core.clj
+++ b/src/prometheus/core.clj
@@ -4,6 +4,7 @@
   (:import
     (clojure.lang IObj)
     (java.io StringWriter)
+    (io.prometheus.client.hotspot DefaultExports)
     (io.prometheus.client.exporter.common TextFormat)
     (io.prometheus.client Counter Histogram Counter$Child Histogram$Child CollectorRegistry Gauge Gauge$Child)))
 
@@ -99,6 +100,12 @@
   [store namespace metric value & {:keys [labels] :or {labels []}}]
   (-> (histogram-with-labels (get-in store [:metrics namespace metric]) labels)
       (.observe value)))
+
+(defn init-defaults
+  "Initialize the metrics system with defaults."
+  []
+  (DefaultExports/initialize)
+  {:registry (CollectorRegistry/defaultRegistry)})
 
 (defn with-path
   "Adds the matched compojure route as the :path response metadata attribute"

--- a/src/prometheus/core.clj
+++ b/src/prometheus/core.clj
@@ -62,21 +62,25 @@
 
 (defn increase-counter
   "Increase the value of a registered counter."
-  [store namespace metric & {:keys [amount labels] :or {amount 1.0 labels []}}]
-  (-> (counter-with-labels (get-in store [:metrics namespace metric]) labels)
-      (.inc amount)))
+  ([store namespace metric] (increase-counter store namespace metric [] 1.0))
+  ([store namespace metric labels] (increase-counter store namespace metric labels 1.0))
+  ([store namespace metric labels amount]
+   (-> (counter-with-labels (get-in store [:metrics namespace metric]) labels)
+       (.inc amount))))
 
 (defn set-gauge
   "Set the value of a registered gauge."
-  [store namespace metric value & {:keys [labels] :or {labels []}}]
-  (-> (gauge-with-labels (get-in store [:metrics namespace metric]) labels)
-      (.set value)))
+  ([store namespace metric value] (set-gauge store namespace metric value []))
+  ([store namespace metric value labels]
+   (-> (gauge-with-labels (get-in store [:metrics namespace metric]) labels)
+       (.set value))))
 
 (defn track-observation
   "Track the value of an observation for a registered histogram."
-  [store namespace metric value & {:keys [labels] :or {labels []}}]
-  (-> (histogram-with-labels (get-in store [:metrics namespace metric]) labels)
-      (.observe value)))
+  ([store namespace metric value] (track-observation store namespace metric value []))
+  ([store namespace metric value labels]
+   (-> (histogram-with-labels (get-in store [:metrics namespace metric]) labels)
+       (.observe value))))
 
 (defn init-defaults
   "Initialize the metrics system with defaults."
@@ -99,7 +103,7 @@
         method-label (string/upper-case (name request-method))
         labels [method-label (str response-status) status-class response-path]]
     (track-observation metrics-store app-name "http_request_latency_seconds" request-time labels)
-    (increase-counter metrics-store app-name "http_requests_total")))
+    (increase-counter metrics-store app-name "http_requests_total" labels)))
 
 (defn instrument-handler
   "Ring middleware to record request metrics"

--- a/src/prometheus/core.clj
+++ b/src/prometheus/core.clj
@@ -5,7 +5,7 @@
     (clojure.lang IObj)
     (java.io StringWriter)
     (io.prometheus.client.exporter.common TextFormat)
-    (io.prometheus.client Counter Histogram Counter$Child Histogram$Child CollectorRegistry)))
+    (io.prometheus.client Counter Histogram Counter$Child Histogram$Child CollectorRegistry Gauge Gauge$Child)))
 
 ; more useful set of buckets for microservice APIs than the defaults provided by the Histogram class
 (def histogram-buckets (atom [0.001, 0.005, 0.010, 0.020, 0.050, 0.100, 0.200, 0.300, 0.500, 0.750, 1, 5]))
@@ -27,16 +27,78 @@
       (.help "A histogram of the response latency for HTTP requests in seconds.")
       (.register registry)))
 
-(defn- ^Counter$Child counter-with-labels [^Counter counter label-array] (.labels counter label-array))
+(defn- ^Counter$Child counter-with-labels [^Counter counter label-array] (.labels counter (into-array String label-array)))
 
-(defn- ^Histogram$Child histogram-with-labels [^Histogram histogram label-array] (.labels histogram label-array))
+(defn- ^Gauge$Child gauge-with-labels [^Gauge gauge labels] (.labels gauge (into-array String labels)))
+
+(defn- ^Histogram$Child histogram-with-labels [^Histogram histogram label-array] (.labels histogram (into-array String label-array)))
 
 (defn- record-request-metric [counter histogram request-method response-status request-time response-path]
   (let [status-class (str (int (/ response-status 100)) "XX")
         method-label (string/upper-case (name request-method))
-        labels (into-array String [method-label (str response-status) status-class response-path])]
+        labels [method-label (str response-status) status-class response-path]]
     (-> (histogram-with-labels histogram labels) (.observe request-time))
     (-> (counter-with-labels counter labels) (.inc))))
+
+(defn- ^Counter make-counter [^CollectorRegistry registry namespace metric help label-names]
+  (-> (Counter/build)
+      (.namespace namespace)
+      (.name metric)
+      (.labelNames (into-array String label-names))
+      (.help help)
+      (.register registry)))
+
+(defn- ^Gauge make-gauge [^CollectorRegistry registry namespace metric help label-names]
+  (-> (Gauge/build)
+      (.namespace namespace)
+      (.name metric)
+      (.labelNames (into-array String label-names))
+      (.help help)
+      (.register registry)))
+
+(defn- ^Histogram make-histogram [^CollectorRegistry registry namespace metric help label-names buckets]
+  (-> (Histogram/build)
+      (.buckets (double-array buckets))
+      (.namespace namespace)
+      (.name metric)
+      (.labelNames (into-array String label-names))
+      (.help help)
+      (.register registry)))
+
+(defn set-gauge
+  "Set the value of a registered gauge."
+  [store namespace metric value & {:keys [labels] :or {labels []}}]
+  (-> (gauge-with-labels (get-in store [:metrics namespace metric]) labels)
+      (.set value)))
+
+(defn register-gauge
+  "Registers a gauge to the store and returns the new store."
+  [store namespace metric help label-names]
+  (assoc-in store [:metrics namespace metric] (make-gauge (:registry store) namespace metric help label-names)))
+
+(defn register-counter
+  "Registers a counter to the store and returns the new store."
+  [store namespace metric help label-names]
+  (assoc-in store [:metrics namespace metric] (make-counter (:registry store) namespace metric help label-names)))
+
+(defn increase-counter
+  "Increase the value of a registered counter."
+  [store namespace metric & {:keys [amount labels] :or {amount 1.0 labels []}}]
+  (-> (counter-with-labels (get-in store [:metrics namespace metric]) labels)
+      (.inc amount)))
+
+(defn register-histogram
+  "Registers a histogram to the store and returns the new store."
+  [store namespace metric help label-names buckets]
+  (assoc-in store
+            [:metrics namespace metric]
+            (make-histogram (:registry store) namespace metric help label-names buckets)))
+
+(defn track-observation
+  "Track the value of an observation for a registered histogram."
+  [store namespace metric value & {:keys [labels] :or {labels []}}]
+  (-> (histogram-with-labels (get-in store [:metrics namespace metric]) labels)
+      (.observe value)))
 
 (defn with-path
   "Adds the matched compojure route as the :path response metadata attribute"

--- a/src/prometheus/example.clj
+++ b/src/prometheus/example.clj
@@ -1,0 +1,31 @@
+(ns prometheus.example
+  (:require [prometheus.core :as prometheus]
+            [ring.server.standalone :refer [serve]]))
+
+(defonce store (atom nil))
+
+(defn register-metrics [store]
+  (->
+    store
+    (prometheus/register-counter "test" "some_counter" "some test" ["foo"])
+    (prometheus/register-gauge "test" "some_gauge" "some test" ["foo"])
+    (prometheus/register-histogram "test" "some_histogram" "some test" ["foo"] [0.7 0.8 0.9])))
+
+(defn init! []
+  (->> (prometheus/init-defaults)
+       (register-metrics)
+       (reset! store)))
+
+(defn handler [_]
+  (prometheus/increase-counter @store "test" "some_counter" ["bar"] 3)
+  (prometheus/set-gauge @store "test" "some_gauge" 101 ["bar"])
+  (prometheus/track-observation @store "test" "some_histogram" 0.71 ["bar"])
+  (prometheus/dump-metrics (:registry @store)))
+
+
+(defn -main [&]
+  (init!)
+  (serve
+    (prometheus/instrument-handler handler
+                                   "test_app"
+                                   (:registry @store))))

--- a/test/prometheus/core_test.clj
+++ b/test/prometheus/core_test.clj
@@ -23,3 +23,33 @@
       (is (.contains (:body metrics) "http_request_latency_seconds"))
       (is (.contains (:body metrics) "http_requests_total"))
       (is (.contains (:body metrics) "/test-path")))))
+
+(deftest custom-metrics
+  (let [registry (CollectorRegistry.)
+        store {:registry registry}]
+    (testing "adds a custom counter"
+      (let [store (prometheus/register-counter store "test" "my_custom_counter" "some counter" ["foo"])]
+        (prometheus/increase-counter store "test" "my_custom_counter" :labels ["bar"])
+        (is (.contains (:body (prometheus/dump-metrics registry)) "test_my_custom_counter"))))
+    (testing "adds a custom gauge"
+      (let [store (prometheus/register-gauge store "test" "my_custom_gauge" "some gauge" ["foo"])]
+        (prometheus/set-gauge store "test" "my_custom_gauge" 101 :labels ["bar"])
+        (is (.contains (:body (prometheus/dump-metrics (:registry store)))
+                       "test_my_custom_gauge{foo=\"bar\",} 101.0"))))
+    (testing "adds a custom histogram"
+      (let [store (prometheus/register-histogram
+                    store
+                    "test"
+                    "my_custom_histogram"
+                    "some histogram"
+                    ["foo"]
+                    [10 90 100])]
+        (prometheus/track-observation store "test" "my_custom_histogram" 87 :labels ["bar"])
+        (is (.contains (:body (prometheus/dump-metrics registry))
+                       "test_my_custom_histogram_bucket{foo=\"bar\",le=\"90.0\",} 1.0"))
+        (is (.contains (:body (prometheus/dump-metrics registry))
+                       "test_my_custom_histogram_bucket{foo=\"bar\",le=\"100.0\",} 1.0"))
+        (is (.contains (:body (prometheus/dump-metrics registry))
+                       "test_my_custom_histogram_sum{foo=\"bar\",} 87.0"))
+        (is (.contains (:body (prometheus/dump-metrics registry))
+                       "test_my_custom_histogram_count{foo=\"bar\",} 1.0"))))))

--- a/test/prometheus/core_test.clj
+++ b/test/prometheus/core_test.clj
@@ -29,11 +29,11 @@
         store {:registry registry}]
     (testing "adds a custom counter"
       (let [store (prometheus/register-counter store "test" "my_custom_counter" "some counter" ["foo"])]
-        (prometheus/increase-counter store "test" "my_custom_counter" :labels ["bar"])
+        (prometheus/increase-counter store "test" "my_custom_counter" ["bar"])
         (is (.contains (:body (prometheus/dump-metrics registry)) "test_my_custom_counter"))))
     (testing "adds a custom gauge"
       (let [store (prometheus/register-gauge store "test" "my_custom_gauge" "some gauge" ["foo"])]
-        (prometheus/set-gauge store "test" "my_custom_gauge" 101 :labels ["bar"])
+        (prometheus/set-gauge store "test" "my_custom_gauge" 101 ["bar"])
         (is (.contains (:body (prometheus/dump-metrics (:registry store)))
                        "test_my_custom_gauge{foo=\"bar\",} 101.0"))))
     (testing "adds a custom histogram"
@@ -44,7 +44,7 @@
                     "some histogram"
                     ["foo"]
                     [10 90 100])]
-        (prometheus/track-observation store "test" "my_custom_histogram" 87 :labels ["bar"])
+        (prometheus/track-observation store "test" "my_custom_histogram" 87 ["bar"])
         (is (.contains (:body (prometheus/dump-metrics registry))
                        "test_my_custom_histogram_bucket{foo=\"bar\",le=\"90.0\",} 1.0"))
         (is (.contains (:body (prometheus/dump-metrics registry))


### PR DESCRIPTION
This:
- [x] adds support for custom metrics (for now counters, gauges & histograms).
- [x] adds the simpleclient_hotspot which brings some default exporters for the jvm.
- [x] adds suppport for the push client.
- [x] brings some docs how to use it.

and shouldn't break any existing API.
