### PR TITLE
feature/upgarde-deps

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,14 +1,14 @@
-(defproject com.soundcloud/prometheus-clj "2.4.1"
+(defproject com.soundcloud/prometheus-clj "2.4.2"
   :description "Clojure wrappers for the Prometheus java client"
   :url "https://github.com/soundcloud/prometheus-clj"
 
   :license {:name "The Apache Software License, Version 2.0"
             :url  "http://www.apache.org/licenses/LICENSE-2.0.txt"}
 
-  :dependencies [[io.prometheus/simpleclient "0.0.14"]
-                 [io.prometheus/simpleclient_hotspot "0.0.14"]
-                 [io.prometheus/simpleclient_common "0.0.14"]
-                 [io.prometheus/simpleclient_pushgateway "0.0.14"]]
+  :dependencies [[io.prometheus/simpleclient "0.8.1"]
+                 [io.prometheus/simpleclient_hotspot "0.8.1"]
+                 [io.prometheus/simpleclient_common "0.8.1"]
+                 [io.prometheus/simpleclient_pushgateway "0.8.1"]]
 
   :min-lein-version "2.4.3"
 


### PR DESCRIPTION
- upgrade java dependencies that caused errors to be thrown on
  push-metrics! calls on newer versions of the push gateway
 old version return status code 202 , new version return status code 200